### PR TITLE
Add brew state

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -46,8 +46,8 @@ ReactDOM.render(
           <title>Brew Control Web</title>
           <meta name="description" content="Brew Control Web"/>
           <link rel="icon"
-                type="image/png"
-                href={Favicon}/>
+            type="image/png"
+            href={Favicon}/>
         </Helmet>
         <Route exact path='/' component={Pricing}/>
         <Route path='/confirmation/:plan/:priceModel' component={Confirmation}/>

--- a/app/pages/confirmation/index.js
+++ b/app/pages/confirmation/index.js
@@ -13,7 +13,7 @@ export default class Confirmation extends React.Component {
         <Row>
           <Col xs={12}>
             <Translate value='confirmation.line'/> <Translate
-            value={`pricing.plan.types.${this.props.match.params.plan}`}/>
+              value={`pricing.plan.types.${this.props.match.params.plan}`}/>
           </Col>
           <Col xs={12}>
             <Link to='/'><Translate value='confirmation.back'/></Link>

--- a/app/pages/pricing/ducks.js
+++ b/app/pages/pricing/ducks.js
@@ -4,20 +4,29 @@ export const PRICING_TYPES = {
 };
 
 export const initialState = {
-  brewingModel: PRICING_TYPES.MONTHLY
+  brewingModel: PRICING_TYPES.MONTHLY,
+  brewStates: []
 };
 
 export const CHANGE_PRICING = 'app/pricing/CHANGE_PRICING';
+export const PREPEND_BREW_STATE = 'app/pricing/PREPEND_BREW_STATE';
+
+const MAX_STATES = 1000000;
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case CHANGE_PRICING:
-      return {
-        ...state,
-        brewingModel: action.payload
-      };
-    default:
-      return state;
+  case CHANGE_PRICING:
+    return {
+      ...state,
+      brewingModel: action.payload
+    };
+  case PREPEND_BREW_STATE:
+    return {
+      ...state,
+      brewStates: [action.brewState, ...state.brewStates].slice(0, MAX_STATES)
+    };
+  default:
+    return state;
   }
 };
 
@@ -31,6 +40,15 @@ export const changePricing = pricingType => {
     payload: pricingType
   };
 };
+
+export const prependBrewState = brewState => {
+  return {
+    type: PREPEND_BREW_STATE,
+    brewState: brewState
+  };
+};
+
+
 
 /**
  * A function that maps the app state the the components properties

--- a/app/pages/pricing/ducks.js
+++ b/app/pages/pricing/ducks.js
@@ -11,7 +11,7 @@ export const initialState = {
 export const CHANGE_PRICING = 'app/pricing/CHANGE_PRICING';
 export const PREPEND_BREW_STATE = 'app/pricing/PREPEND_BREW_STATE';
 
-const MAX_STATES = 1000000;
+export const MAX_STATES = 1000000;
 
 export default (state = initialState, action) => {
   switch (action.type) {

--- a/app/pages/pricing/tests/ducks.test.js
+++ b/app/pages/pricing/tests/ducks.test.js
@@ -15,8 +15,19 @@ test('Reducer will supply its own initialState when none is given', () => {
   expect(out).toEqual(pricingDuck.initialState);
 });
 
-test('Reducer should recieve action and update state', () => {
+test('Reducer should recieve changePricing action and update state', () => {
   const initialState = {};
   const out = reducer(initialState, pricingDuck.changePricing(pricingDuck.PRICING_TYPES.MONTHLY));
   expect(out).toEqual({brewingModel: 'originalGravity'});
+});
+
+
+test('Reducer should recieve prependBrewingState action and update state', () => {
+  const initialState = {brewStates: []};
+  const out1 = reducer(initialState, pricingDuck.prependBrewState('state1'));
+  expect(out1).toEqual({'brewStates': ['state1']});
+
+  const out2 = reducer(out1, pricingDuck.prependBrewState('state2'));
+  expect(out1).toEqual({'brewStates': ['state1']});
+  expect(out2).toEqual({'brewStates': ['state2', 'state1']});
 });

--- a/app/pages/pricing/tests/ducks.test.js
+++ b/app/pages/pricing/tests/ducks.test.js
@@ -30,16 +30,16 @@ test('Reducer should receive prependBrewingState action and update state', () =>
   const out2 = reducer(out1, pricingDuck.prependBrewState('state2'));
   expect(out1).toEqual({'brewStates': ['state1']});
   expect(out2).toEqual({'brewStates': ['state2', 'state1']});
-})
+});
 
-test('Max states should be pretty big', () => {expect(pricingDuck.MAX_STATES).toBeGreaterThan(10000)})
+test('Max states should be pretty big', () => {expect(pricingDuck.MAX_STATES).toBeGreaterThan(10000);});
 
 test('Reducer should receive prependBrewingState repeatedly but truncate the array eventually', () => {
   const initialState = {brewStates: Array.from(Array(pricingDuck.MAX_STATES).keys())};
   expect(initialState.brewStates.length).toEqual(pricingDuck.MAX_STATES);
 
   const out = reducer(initialState, pricingDuck.prependBrewState(-1));
-  const brewStates = out.brewStates
+  const brewStates = out.brewStates;
   expect(brewStates[0]).toEqual(-1);
   expect(brewStates[1]).toEqual(0);
   expect(brewStates.slice(-1)[0]).toEqual(pricingDuck.MAX_STATES-2);

--- a/app/pages/pricing/tests/ducks.test.js
+++ b/app/pages/pricing/tests/ducks.test.js
@@ -4,7 +4,7 @@ test('Constant should be constant', () => {
   expect(pricingDuck.CHANGE_PRICING).toEqual('app/pricing/CHANGE_PRICING');
 });
 
-test('Reducer should return the initial state if an unknown action is recieved', () => {
+test('Reducer should return the initial state if an unknown action is received', () => {
   const initialState = {};
   const out = reducer(initialState, {type: 'UNKNOWN', payload: 'junk'});
   expect(out).toEqual(initialState);
@@ -15,14 +15,14 @@ test('Reducer will supply its own initialState when none is given', () => {
   expect(out).toEqual(pricingDuck.initialState);
 });
 
-test('Reducer should recieve changePricing action and update state', () => {
+test('Reducer should receive changePricing action and update state', () => {
   const initialState = {};
   const out = reducer(initialState, pricingDuck.changePricing(pricingDuck.PRICING_TYPES.MONTHLY));
   expect(out).toEqual({brewingModel: 'originalGravity'});
 });
 
 
-test('Reducer should recieve prependBrewingState action and update state', () => {
+test('Reducer should receive prependBrewingState action and update state', () => {
   const initialState = {brewStates: []};
   const out1 = reducer(initialState, pricingDuck.prependBrewState('state1'));
   expect(out1).toEqual({'brewStates': ['state1']});
@@ -30,4 +30,19 @@ test('Reducer should recieve prependBrewingState action and update state', () =>
   const out2 = reducer(out1, pricingDuck.prependBrewState('state2'));
   expect(out1).toEqual({'brewStates': ['state1']});
   expect(out2).toEqual({'brewStates': ['state2', 'state1']});
+})
+
+test('Max states should be pretty big', () => {expect(pricingDuck.MAX_STATES).toBeGreaterThan(10000)})
+
+test('Reducer should receive prependBrewingState repeatedly but truncate the array eventually', () => {
+  const initialState = {brewStates: Array.from(Array(pricingDuck.MAX_STATES).keys())};
+  expect(initialState.brewStates.length).toEqual(pricingDuck.MAX_STATES);
+
+  const out = reducer(initialState, pricingDuck.prependBrewState(-1));
+  const brewStates = out.brewStates
+  expect(brewStates[0]).toEqual(-1);
+  expect(brewStates[1]).toEqual(0);
+  expect(brewStates.slice(-1)[0]).toEqual(pricingDuck.MAX_STATES-2);
+
+
 });


### PR DESCRIPTION
To track the state of the brew, we'll keep an array of brew states as acquired from the arduino server. 

This PR just adds the array to the redux store and implements a reducer for adding brew states.